### PR TITLE
Rename VegaFusionModuleLoader -> VlConvertModuleLoader

### DIFF
--- a/vl-convert-rs/src/converter.rs
+++ b/vl-convert-rs/src/converter.rs
@@ -1,5 +1,5 @@
 use crate::module_loader::import_map::VlVersion;
-use crate::module_loader::VegaFusionModuleLoader;
+use crate::module_loader::VlConvertModuleLoader;
 use deno_core::error::AnyError;
 use deno_core::{serde_v8, v8, JsRuntime, RuntimeOptions};
 use std::collections::HashSet;
@@ -66,7 +66,7 @@ function compileVegaLite_{ver_name}(vlSpec, pretty) {{
     }
 
     pub fn new() -> Self {
-        let module_loader = Rc::new(VegaFusionModuleLoader::new());
+        let module_loader = Rc::new(VlConvertModuleLoader::new());
         let js_runtime = JsRuntime::new(RuntimeOptions {
             module_loader: Some(module_loader),
             ..Default::default()

--- a/vl-convert-rs/src/module_loader/mod.rs
+++ b/vl-convert-rs/src/module_loader/mod.rs
@@ -9,11 +9,11 @@ use deno_core::{
 use std::collections::HashMap;
 use std::pin::Pin;
 
-pub struct VegaFusionModuleLoader {
+pub struct VlConvertModuleLoader {
     import_map: HashMap<String, String>,
 }
 
-impl VegaFusionModuleLoader {
+impl VlConvertModuleLoader {
     pub fn new() -> Self {
         Self {
             import_map: build_import_map(),
@@ -21,13 +21,13 @@ impl VegaFusionModuleLoader {
     }
 }
 
-impl Default for VegaFusionModuleLoader {
+impl Default for VlConvertModuleLoader {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ModuleLoader for VegaFusionModuleLoader {
+impl ModuleLoader for VlConvertModuleLoader {
     fn resolve(
         &self,
         specifier: &str,


### PR DESCRIPTION
Module loader code was copied from an old VegaFusion prototype and I forgot to rename the struct