### PR TITLE
Add fallback textinfo

### DIFF
--- a/vl-convert-rs/src/text.rs
+++ b/vl-convert-rs/src/text.rs
@@ -139,7 +139,7 @@ pub fn op_text_width(text_info_str: String) -> Result<f64, AnyError> {
 
 fn extract_text_width(svg: &String) -> Result<f64, AnyError> {
     let rtree =
-        usvg::Tree::from_str(&svg, &USVG_OPTIONS.to_ref()).expect("Failed to parse text SVG");
+        usvg::Tree::from_str(svg, &USVG_OPTIONS.to_ref()).expect("Failed to parse text SVG");
     for node in rtree.root().descendants() {
         if !rtree.is_in_defs(&node) {
             // Text bboxes are different from path bboxes.


### PR DESCRIPTION
## Background
0.3.0rc1 fails on binder with this error:

<img width="1352" alt="Screen Shot 2022-10-16 at 5 01 16 PM" src="https://user-images.githubusercontent.com/15064365/196060340-27d63815-0939-4158-8e46-67ba4efee5ca.png">

This PR adds a fallback to the text width calculation. When text width calculation fails, we fallback to using the "sans-serif" font family that is always supported. It also adds some extra info to the error message above.