### PR TITLE
Font fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,7 @@ version = "0.3.0-rc2"
 dependencies = [
  "deno_core",
  "deno_runtime",
+ "fontdb",
  "futures",
  "futures-util",
  "lazy_static",

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,0 @@
-echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-apt-get install -y ttf-mscorefonts-installer

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
-echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
 apt-get install -y ttf-mscorefonts-installer

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-sudo apt-get install -y ttf-mscorefonts-installer
+apt-get install -y ttf-mscorefonts-installer

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+sudo apt-get install -y ttf-mscorefonts-installer

--- a/vl-convert-rs/Cargo.toml
+++ b/vl-convert-rs/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4.0"
 usvg = "0.23.0"
 resvg = "0.23.0"
 tiny-skia = "0.6"
+fontdb = {version="0.9.1", features=["fontconfig"]}
 
 [dev-dependencies]
 tokio = {version="1.21.2", features=["macros", "rt", "rt-multi-thread"]}

--- a/vl-convert-rs/src/text.rs
+++ b/vl-convert-rs/src/text.rs
@@ -49,7 +49,12 @@ fn init_usvg_options() -> usvg::Options {
     }
 
     // Set default monospace font family
-    for family in ["Courier New", "Courier", "Liberation Mono"] {
+    for family in [
+        "Courier New",
+        "Courier",
+        "Liberation Mono",
+        "DejaVu Sans Mono",
+    ] {
         if families.contains(family) {
             opt.fontdb.set_monospace_family(family);
             break;
@@ -57,7 +62,12 @@ fn init_usvg_options() -> usvg::Options {
     }
 
     // Set default serif font family
-    for family in ["Times New Roman", "Times", "Liberation Serif"] {
+    for family in [
+        "Times New Roman",
+        "Times",
+        "Liberation Serif",
+        "DejaVu Serif",
+    ] {
         if families.contains(family) {
             opt.fontdb.set_serif_family(family);
             break;

--- a/vl-convert-rs/src/text.rs
+++ b/vl-convert-rs/src/text.rs
@@ -8,12 +8,13 @@ lazy_static! {
     pub static ref USVG_OPTIONS: usvg::Options = init_usvg_options();
 }
 
-const SANS_SERIF_REGULAR: &[u8] =
+const LIBERATION_SANS_REGULAR: &[u8] =
     include_bytes!("../fonts/liberation-sans/LiberationSans-Regular.ttf");
-const SANS_SERIF_BOLD: &[u8] = include_bytes!("../fonts/liberation-sans/LiberationSans-Bold.ttf");
-const SANS_SERIF_ITALIC: &[u8] =
+const LIBERATION_SANS_BOLD: &[u8] =
+    include_bytes!("../fonts/liberation-sans/LiberationSans-Bold.ttf");
+const LIBERATION_SANS_ITALIC: &[u8] =
     include_bytes!("../fonts/liberation-sans/LiberationSans-Italic.ttf");
-const SANS_SERIF_BOLDITALIC: &[u8] =
+const LIBERATION_SANS_BOLDITALIC: &[u8] =
     include_bytes!("../fonts/liberation-sans/LiberationSans-BoldItalic.ttf");
 
 fn init_usvg_options() -> usvg::Options {
@@ -22,6 +23,16 @@ fn init_usvg_options() -> usvg::Options {
     // Load fonts from the operating system
     opt.fontdb.load_system_fonts();
 
+    // Set default sans-serif font family.
+    // By default, Vega outputs SVGs with "sans-serif" as the font family, so
+    // we vendor the "Liberation Sans" font so that there is always a fallback
+    opt.fontdb
+        .load_font_data(Vec::from(LIBERATION_SANS_REGULAR));
+    opt.fontdb.load_font_data(Vec::from(LIBERATION_SANS_BOLD));
+    opt.fontdb.load_font_data(Vec::from(LIBERATION_SANS_ITALIC));
+    opt.fontdb
+        .load_font_data(Vec::from(LIBERATION_SANS_BOLDITALIC));
+
     // Collect set of system font families
     let families: HashSet<String> = opt
         .fontdb
@@ -29,14 +40,6 @@ fn init_usvg_options() -> usvg::Options {
         .iter()
         .map(|face| face.family.clone())
         .collect();
-
-    // Set default sans-serif font family.
-    // By default, Vega outputs SVGs with "sans-serif" as the font family, so
-    // we vendor the "Liberation Sans" font so that there is always a fallback
-    opt.fontdb.load_font_data(Vec::from(SANS_SERIF_REGULAR));
-    opt.fontdb.load_font_data(Vec::from(SANS_SERIF_BOLD));
-    opt.fontdb.load_font_data(Vec::from(SANS_SERIF_ITALIC));
-    opt.fontdb.load_font_data(Vec::from(SANS_SERIF_BOLDITALIC));
 
     for family in ["Arial", "Helvetica", "Liberation Sans"] {
         if families.contains(family) {


### PR DESCRIPTION
Various fixes and improvements to font handling:
 - Fix logic error in vendored Liberation Sans font handling. We were computing the set of available font families before registering the vendored Liberation Sans fonts
 - Use the `fontconfig` feature flag to the `fontdb` crate to look up system fonts dynamically based on `fontconfig` configuration files.
 - Include `DejaVu*` font fallback for monospace and serif (These are available in ubuntu minimal images).